### PR TITLE
Count quinolones for ariba calls

### DIFF
--- a/python/evalrescallers/res_caller.py
+++ b/python/evalrescallers/res_caller.py
@@ -180,10 +180,18 @@ class ResCaller:
         quinolones = {'Ciprofloxacin', 'Moxifloxacin', 'Ofloxacin'}
 
         if caller == 'ARIBA':
+            quinolone_calls = set()
+
             for drug in json_data:
                 resistance_calls[drug] = []
                 for t in json_data[drug]:
-                    resistance_calls[drug].append(('R', t[0], t[1], None))
+                    to_append = ('R', t[0], t[1], None)
+                    resistance_calls[drug].append(to_append)
+                    if drug in quinolones:
+                        quinolone_calls.add(to_append)
+
+            if len(quinolone_calls) > 0:
+                resistance_calls['Quinolones'] = sorted(list(quinolone_calls))
         elif caller == 'KvarQ':
             try:
                 res_list = json_data['analyses']['MTBC/resistance']

--- a/python/evalrescallers/tests/data/res_caller/json_to_resistance_calls.ARIBA.json
+++ b/python/evalrescallers/tests/data/res_caller/json_to_resistance_calls.ARIBA.json
@@ -20,5 +20,11 @@
             "gyrA",
             "A90V"
         ]
+    ],
+    "Ofloxacin": [
+        [
+            "gyrA",
+            "A90V"
+        ]
     ]
 }

--- a/python/evalrescallers/tests/res_caller_test.py
+++ b/python/evalrescallers/tests/res_caller_test.py
@@ -65,6 +65,8 @@ class TestResCaller(unittest.TestCase):
             'Ethambutol': [('R', 'embA_upstream', 'C-12T', None), ('R', 'embB', 'M306I', None)],
             'Isoniazid': [('R', 'katG', 'S315T', None)],
             'Moxifloxacin': [('R', 'gyrA', 'A90V', None)],
+            'Ofloxacin': [('R', 'gyrA', 'A90V', None)],
+            'Quinolones': [('R', 'gyrA', 'A90V', None)],
         }
         got = res_caller.ResCaller._json_to_resistance_calls(json_file, 'ARIBA')
         self.assertEqual(expected, got)


### PR DESCRIPTION
ARIBA uses new mykrobe panel, which has quinolones separated out. This change counts the total for 'quinolones', as well as the separate counts per drug.